### PR TITLE
Fix `overlay` background in delete page

### DIFF
--- a/packages/app/src/pages/SkuDetails.tsx
+++ b/packages/app/src/pages/SkuDetails.tsx
@@ -147,7 +147,7 @@ export const SkuDetails: FC = () => {
         </Spacer>
       </SkeletonTemplate>
       {canUser('destroy', 'skus') && (
-        <Overlay>
+        <Overlay backgroundColor='light'>
           <PageLayout
             title={`Confirm that you want to cancel the ${sku.code} (${sku.name}) SKU.`}
             description='This action cannot be undone, proceed with caution.'
@@ -159,7 +159,6 @@ export const SkuDetails: FC = () => {
               label: `Cancel`,
               icon: 'x'
             }}
-            overlay
           >
             <Button
               variant='danger'


### PR DESCRIPTION
<!-- Thank you for contributing to Commerce Layer! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

Added the `backgroundColor='light'` prop to the SKU delete `Overlay` and remove the `overlay` prop in the inner `PageLayout`

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
