### PR TITLE
Replace stock tracking labels

### DIFF
--- a/packages/app/src/components/SkuForm.tsx
+++ b/packages/app/src/components/SkuForm.tsx
@@ -251,7 +251,7 @@ export function SkuForm({
           <Spacer top='2' bottom='12'>
             <HookedInputCheckbox name='doNotTrack'>
               <Text weight='semibold' size='small'>
-                Do not track
+                Do not track stock
               </Text>
             </HookedInputCheckbox>
           </Spacer>

--- a/packages/app/src/components/SkuInfo.tsx
+++ b/packages/app/src/components/SkuInfo.tsx
@@ -40,7 +40,7 @@ export const SkuInfo: FC<Props> = ({ sku = makeSku() }) => {
       {sku.do_not_track != null && sku.do_not_track ? (
         <ListDetailsItem label='Tracking' childrenAlign='right'>
           <Text tag='div' weight='semibold'>
-            {sku.do_not_track ? 'Do not track' : ''}
+            {sku.do_not_track ? 'Do not track stock' : ''}
           </Text>
         </ListDetailsItem>
       ) : null}


### PR DESCRIPTION
<!-- Thank you for contributing to Commerce Layer! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

Replaced stock tracking labels. Old label was `Do not track`. New label is now `Do not track stock`.

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
