### PR TITLE
Enforce SKU form and refine error spacing

### DIFF
--- a/packages/app/src/components/SkuForm.tsx
+++ b/packages/app/src/components/SkuForm.tsx
@@ -41,7 +41,7 @@ const skuFormSchema = z.object({
   name: z.string().min(1),
   description: z.string().optional(),
   imageUrl: z.string().optional(),
-  shippingCategory: z.string().min(1).or(z.undefined()),
+  shippingCategory: z.string().min(1),
   piecesPerPack: z.string().optional(),
   hsTariffNumber: z.string().optional(),
   doNotShip: z.boolean().optional(),
@@ -265,7 +265,9 @@ export function SkuForm({
           >
             {defaultValues?.name == null ? 'Create' : 'Update'}
           </Button>
-          <HookedValidationApiError apiError={apiError} />
+          <Spacer top='2'>
+            <HookedValidationApiError apiError={apiError} />
+          </Spacer>
         </Spacer>
       </HookedForm>
       <ImageOverlay>

--- a/packages/app/src/pages/SkuEdit.tsx
+++ b/packages/app/src/pages/SkuEdit.tsx
@@ -106,7 +106,7 @@ function adaptSkuToFormValues(sku?: Sku): SkuFormValues {
     code: sku?.code ?? '',
     name: sku?.name ?? '',
     description: sku?.description ?? '',
-    shippingCategory: sku?.shipping_category?.id,
+    shippingCategory: sku?.shipping_category?.id ?? '',
     weight: sku?.weight?.toString() ?? '',
     unitOfWeight: sku?.unit_of_weight ?? '',
     piecesPerPack: sku?.pieces_per_pack?.toString() ?? '',


### PR DESCRIPTION
<!-- Thank you for contributing to Commerce Layer! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

- Enforced the SKU form by setting the `shipping_category` as a required field according to API specifications
- Refined the UI of the SKU form by adding a `Spacer` before the form errors according to other apps positioning

## How to test

<!-- Please include the steps to test your changes here -->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
