### PR TITLE
Add metadata support

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -15,7 +15,7 @@
     "prepare": "touch ./public/config.local.js"
   },
   "dependencies": {
-    "@commercelayer/app-elements": "1.20.1",
+    "@commercelayer/app-elements": "1.23.1",
     "@commercelayer/sdk": "5.36.0",
     "@hookform/resolvers": "^3.3.4",
     "lodash": "^4.17.21",

--- a/packages/app/src/pages/SkuDetails.tsx
+++ b/packages/app/src/pages/SkuDetails.tsx
@@ -6,11 +6,13 @@ import {
   EmptyState,
   Icon,
   PageLayout,
+  ResourceMetadata,
   ResourceTags,
   SkeletonTemplate,
   Spacer,
   goBack,
   useCoreSdkProvider,
+  useEditMetadataOverlay,
   useOverlay,
   useTokenProvider
 } from '@commercelayer/app-elements'
@@ -42,6 +44,9 @@ export const SkuDetails: FC = () => {
 
   const [isDeleteting, setIsDeleting] = useState(false)
 
+  const { Overlay: EditMetadataOverlay, show: showEditMetadataOverlay } =
+    useEditMetadataOverlay()
+
   if (error != null) {
     return (
       <PageLayout
@@ -70,12 +75,20 @@ export const SkuDetails: FC = () => {
   const pageTitle = sku.name
 
   const contextMenuEdit = canUser('update', 'skus') && (
-    <DropdownItem
-      label='Edit'
-      onClick={() => {
-        setLocation(appRoutes.edit.makePath({ skuId }))
-      }}
-    />
+    <>
+      <DropdownItem
+        label='Edit'
+        onClick={() => {
+          setLocation(appRoutes.edit.makePath({ skuId }))
+        }}
+      />
+      <DropdownItem
+        label='Set metadata'
+        onClick={() => {
+          showEditMetadataOverlay()
+        }}
+      />
+    </>
   )
 
   const contextMenuDivider = canUser('update', 'skus') &&
@@ -150,6 +163,18 @@ export const SkuDetails: FC = () => {
           <Spacer top='14'>
             <SkuInfo sku={sku} />
           </Spacer>
+          {!isMockedId(sku.id) && (
+            <Spacer top='14'>
+              <ResourceMetadata
+                resourceType='skus'
+                resourceId={sku.id}
+                overlay={{
+                  title: sku.name,
+                  description: sku.code
+                }}
+              />
+            </Spacer>
+          )}
         </Spacer>
       </SkeletonTemplate>
       {canUser('destroy', 'skus') && (
@@ -186,6 +211,14 @@ export const SkuDetails: FC = () => {
             </Button>
           </PageLayout>
         </Overlay>
+      )}
+      {!isMockedId(sku.id) && (
+        <EditMetadataOverlay
+          resourceType={sku.type}
+          resourceId={sku.id}
+          title={sku.name}
+          description={sku.code}
+        />
       )}
     </PageLayout>
   )

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,8 +28,8 @@ importers:
   packages/app:
     dependencies:
       '@commercelayer/app-elements':
-        specifier: 1.20.1
-        version: 1.20.1(@commercelayer/sdk@5.36.0)(query-string@8.2.0)(react-dom@18.2.0)(react-gtm-module@2.0.11)(react-hook-form@7.51.2)(react@18.2.0)(wouter@3.1.0)
+        specifier: 1.23.1
+        version: 1.23.1(@commercelayer/sdk@5.36.0)(query-string@8.2.0)(react-dom@18.2.0)(react-gtm-module@2.0.11)(react-hook-form@7.51.2)(react@18.2.0)(wouter@3.1.0)
       '@commercelayer/sdk':
         specifier: 5.36.0
         version: 5.36.0
@@ -367,8 +367,8 @@ packages:
     dev: true
     optional: true
 
-  /@commercelayer/app-elements@1.20.1(@commercelayer/sdk@5.36.0)(query-string@8.2.0)(react-dom@18.2.0)(react-gtm-module@2.0.11)(react-hook-form@7.51.2)(react@18.2.0)(wouter@3.1.0):
-    resolution: {integrity: sha512-dAFLQor01lkupmb8SdQqzdCyxlU5/NnKKzJt3q7d6CsXMA2wOPOxNTR78jU3KhrOGwu96bK1boTv55Ypkf22LA==}
+  /@commercelayer/app-elements@1.23.1(@commercelayer/sdk@5.36.0)(query-string@8.2.0)(react-dom@18.2.0)(react-gtm-module@2.0.11)(react-hook-form@7.51.2)(react@18.2.0)(wouter@3.1.0):
+    resolution: {integrity: sha512-ZDRTIayGDM0lLfS4OGGfbu7W0AWTZjMIz+Jy9BZKDLyC5/EY/mncB635viVantw+aZko42efQ2aeKVdMDJcIFA==}
     engines: {node: '>=18', pnpm: '>=7'}
     peerDependencies:
       '@commercelayer/sdk': ^5.x
@@ -381,9 +381,9 @@ packages:
     dependencies:
       '@commercelayer/sdk': 5.36.0
       '@types/lodash': 4.17.0
-      '@types/react': 18.2.74
-      '@types/react-datepicker': 6.0.3(react-dom@18.2.0)(react@18.2.0)
-      '@types/react-dom': 18.2.24
+      '@types/react': 18.2.79
+      '@types/react-datepicker': 6.2.0(react-dom@18.2.0)(react@18.2.0)
+      '@types/react-dom': 18.2.25
       classnames: 2.5.1
       jwt-decode: 4.0.0
       lodash: 4.17.21
@@ -391,11 +391,11 @@ packages:
       query-string: 8.2.0
       react: 18.2.0
       react-currency-input-field: 3.8.0(react@18.2.0)
-      react-datepicker: 6.1.0(react-dom@18.2.0)(react@18.2.0)
+      react-datepicker: 6.9.0(react-dom@18.2.0)(react@18.2.0)
       react-dom: 18.2.0(react@18.2.0)
       react-gtm-module: 2.0.11
       react-hook-form: 7.51.2(react@18.2.0)
-      react-select: 5.8.0(@types/react@18.2.74)(react-dom@18.2.0)(react@18.2.0)
+      react-select: 5.8.0(@types/react@18.2.79)(react-dom@18.2.0)(react@18.2.0)
       react-tooltip: 5.26.3(react-dom@18.2.0)(react@18.2.0)
       swr: 2.2.5(react@18.2.0)
       ts-invariant: 0.10.3
@@ -493,7 +493,7 @@ packages:
     resolution: {integrity: sha512-W2P2c/VRW1/1tLox0mVUalvnWXxavmv/Oum2aPsRcoDJuob75FC3Y8FbpfLwUegRcxINtGUMPq0tFCvYNTBXNA==}
     dev: false
 
-  /@emotion/react@11.11.3(@types/react@18.2.74)(react@18.2.0):
+  /@emotion/react@11.11.3(@types/react@18.2.79)(react@18.2.0):
     resolution: {integrity: sha512-Cnn0kuq4DoONOMcnoVsTOR8E+AdnKFf//6kUWc4LCdnxj31pZWn7rIULd6Y7/Js1PiPHzn7SKCM9vB/jBni8eA==}
     peerDependencies:
       '@types/react': '*'
@@ -509,7 +509,7 @@ packages:
       '@emotion/use-insertion-effect-with-fallbacks': 1.0.1(react@18.2.0)
       '@emotion/utils': 1.2.1
       '@emotion/weak-memoize': 0.3.1
-      '@types/react': 18.2.74
+      '@types/react': 18.2.79
       hoist-non-react-statics: 3.3.2
       react: 18.2.0
     dev: false
@@ -1792,11 +1792,11 @@ packages:
   /@types/prop-types@15.7.11:
     resolution: {integrity: sha512-ga8y9v9uyeiLdpKddhxYQkxNDrfvuPrlFb0N1qnZZByvcElJaXthF1UhvCh9TLWJBEHeNtdnbysW7Y6Uq8CVng==}
 
-  /@types/react-datepicker@6.0.3(react-dom@18.2.0)(react@18.2.0):
-    resolution: {integrity: sha512-3x5flRBrEgC3fFrBryFIrxbLf8bOkte/GNryPjfnXu3my4/XZeaML/01U+XArMCLfk2d3pei6ccNIgTlpe4c5g==}
+  /@types/react-datepicker@6.2.0(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-+JtO4Fm97WLkJTH8j8/v3Ldh7JCNRwjMYjRaKh4KHH0M3jJoXtwiD3JBCsdlg3tsFIw9eQSqyAPeVDN2H2oM9Q==}
     dependencies:
       '@floating-ui/react': 0.26.9(react-dom@18.2.0)(react@18.2.0)
-      '@types/react': 18.2.74
+      '@types/react': 18.2.79
       date-fns: 3.3.1
     transitivePeerDependencies:
       - react
@@ -1807,11 +1807,18 @@ packages:
     resolution: {integrity: sha512-cN6upcKd8zkGy4HU9F1+/s98Hrp6D4MOcippK4PoE8OZRngohHZpbJn1GsaDLz87MqvHNoT13nHvNqM9ocRHZg==}
     dependencies:
       '@types/react': 18.2.74
+    dev: true
+
+  /@types/react-dom@18.2.25:
+    resolution: {integrity: sha512-o/V48vf4MQh7juIKZU2QGDfli6p1+OOi5oXx36Hffpc9adsHeXjVp8rHuPkjd8VT8sOJ2Zp05HR7CdpGTIUFUA==}
+    dependencies:
+      '@types/react': 18.2.79
+    dev: false
 
   /@types/react-transition-group@4.4.10:
     resolution: {integrity: sha512-hT/+s0VQs2ojCX823m60m5f0sL5idt9SO6Tj6Dg+rdphGPIeJbJ6CxvBYkgkGKrYeDjvIpKTR38UzmtHJOGW3Q==}
     dependencies:
-      '@types/react': 18.2.74
+      '@types/react': 18.2.79
     dev: false
 
   /@types/react@18.2.74:
@@ -1819,6 +1826,14 @@ packages:
     dependencies:
       '@types/prop-types': 15.7.11
       csstype: 3.1.2
+    dev: true
+
+  /@types/react@18.2.79:
+    resolution: {integrity: sha512-RwGAGXPl9kSXwdNTafkOEuFrTBD5SA2B3iEB96xi8+xu5ddUa/cpvyVCSNn+asgLCTHkb5ZxN8gbuibYJi4s1w==}
+    dependencies:
+      '@types/prop-types': 15.7.11
+      csstype: 3.1.2
+    dev: false
 
   /@types/semver-utils@1.1.3:
     resolution: {integrity: sha512-T+YwkslhsM+CeuhYUxyAjWm7mJ5am/K10UX40RuA6k6Lc7eGtq8iY2xOzy7Vq0GOqhl/xZl5l2FwURZMTPTUww==}
@@ -2833,6 +2848,11 @@ packages:
     resolution: {integrity: sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==}
     engines: {node: '>=0.8'}
     dev: true
+
+  /clsx@2.1.1:
+    resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
+    engines: {node: '>=6'}
+    dev: false
 
   /cmd-shim@6.0.1:
     resolution: {integrity: sha512-S9iI9y0nKR4hwEQsVWpyxld/6kRfGepGfzff83FcaiEBpmvlbA2nnGe7Cylgrx2f/p1P5S5wpRm9oL8z1PbS3Q==}
@@ -7240,14 +7260,14 @@ packages:
       react: 18.2.0
     dev: false
 
-  /react-datepicker@6.1.0(react-dom@18.2.0)(react@18.2.0):
-    resolution: {integrity: sha512-8uz+hAOpvHqZGvD4Ky1hJ0/tLI4S9B0Gu9LV7LtLxRKXODs/xrxEay0aMVp7AW9iizTeImZh/6aA00fFaRZpJw==}
+  /react-datepicker@6.9.0(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-QTxuzeem7BUfVFWv+g5WuvzT0c5BPo+XTCNbMTZKSZQLU+cMMwSUHwspaxuIcDlwNcOH0tiJ+bh1fJ2yxOGYWA==}
     peerDependencies:
       react: ^16.9.0 || ^17 || ^18
       react-dom: ^16.9.0 || ^17 || ^18
     dependencies:
       '@floating-ui/react': 0.26.9(react-dom@18.2.0)(react@18.2.0)
-      classnames: 2.5.1
+      clsx: 2.1.1
       date-fns: 3.3.1
       prop-types: 15.8.1
       react: 18.2.0
@@ -7303,7 +7323,7 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: true
 
-  /react-select@5.8.0(@types/react@18.2.74)(react-dom@18.2.0)(react@18.2.0):
+  /react-select@5.8.0(@types/react@18.2.79)(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-TfjLDo58XrhP6VG5M/Mi56Us0Yt8X7xD6cDybC7yoRMUNm7BGO7qk8J0TLQOua/prb8vUOtsfnXZwfm30HGsAA==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
@@ -7311,7 +7331,7 @@ packages:
     dependencies:
       '@babel/runtime': 7.23.4
       '@emotion/cache': 11.11.0
-      '@emotion/react': 11.11.3(@types/react@18.2.74)(react@18.2.0)
+      '@emotion/react': 11.11.3(@types/react@18.2.79)(react@18.2.0)
       '@floating-ui/dom': 1.6.1
       '@types/react-transition-group': 4.4.10
       memoize-one: 6.0.0
@@ -7319,7 +7339,7 @@ packages:
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       react-transition-group: 4.4.5(react-dom@18.2.0)(react@18.2.0)
-      use-isomorphic-layout-effect: 1.1.2(@types/react@18.2.74)(react@18.2.0)
+      use-isomorphic-layout-effect: 1.1.2(@types/react@18.2.79)(react@18.2.0)
     transitivePeerDependencies:
       - '@types/react'
     dev: false
@@ -8759,7 +8779,7 @@ packages:
       requires-port: 1.0.0
     dev: true
 
-  /use-isomorphic-layout-effect@1.1.2(@types/react@18.2.74)(react@18.2.0):
+  /use-isomorphic-layout-effect@1.1.2(@types/react@18.2.79)(react@18.2.0):
     resolution: {integrity: sha512-49L8yCO3iGT/ZF9QttjwLF/ZD9Iwto5LnH5LmEdk/6cFmXddqi2ulF0edxTwjj+7mqvpVVGQWvbXZdn32wRSHA==}
     peerDependencies:
       '@types/react': '*'
@@ -8768,7 +8788,7 @@ packages:
       '@types/react':
         optional: true
     dependencies:
-      '@types/react': 18.2.74
+      '@types/react': 18.2.79
       react: 18.2.0
     dev: false
 


### PR DESCRIPTION
<!-- Thank you for contributing to Commerce Layer! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

Added metadata integration in SKU detail page. If existing, the metadata are visible in page after the `Info` block.
The dropdown item `Set metadata` is always visible if user is able to update sku resources.

<img width="693" alt="Screenshot 2024-04-23 alle 22 24 55" src="https://github.com/commercelayer/app-skus/assets/105653649/af16ecaf-cb72-48de-b462-b71198e87b74">

<img width="662" alt="Screenshot 2024-04-23 alle 22 25 11" src="https://github.com/commercelayer/app-skus/assets/105653649/fcb5656f-3ae9-4220-a66b-6653c660f089">

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
