### PR TITLE
Make shipping category optional when do not ship is checked

### DIFF
--- a/packages/app/src/components/SkuInfo.tsx
+++ b/packages/app/src/components/SkuInfo.tsx
@@ -15,15 +15,17 @@ interface Props {
 export const SkuInfo: FC<Props> = ({ sku = makeSku() }) => {
   return (
     <Section title='Info'>
-      <ListDetailsItem
-        label='Shipping category'
-        childrenAlign='right'
-        gutter='none'
-      >
-        <Text tag='div' weight='semibold'>
-          {sku.shipping_category?.name}
-        </Text>
-      </ListDetailsItem>
+      {sku.shipping_category != null && (
+        <ListDetailsItem
+          label='Shipping category'
+          childrenAlign='right'
+          gutter='none'
+        >
+          <Text tag='div' weight='semibold'>
+            {sku.shipping_category?.name}
+          </Text>
+        </ListDetailsItem>
+      )}
       {sku.weight != null && sku.weight > 0 ? (
         <ListDetailsItem label='Weight' childrenAlign='right' gutter='none'>
           <Text tag='div' weight='semibold'>


### PR DESCRIPTION
## What I did

When creating / updating a SKU, the shipping category is optional if `do_not_ship` is true.

https://github.com/user-attachments/assets/1d5a1464-7053-4488-9480-f9b8efc44e12
 
## How to test




<!-- Please include the steps to test your changes here -->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes.
- [ ] You are **NOT** deprecating/removing a feature.
